### PR TITLE
Port forwarding for Jekyll cmd

### DIFF
--- a/cmd/jekyll.go
+++ b/cmd/jekyll.go
@@ -1,8 +1,12 @@
 package cmd
 
 import "github.com/skybet/cali"
+import "github.com/docker/go-connections/nat"
 import "os/user"
 import log "github.com/Sirupsen/logrus"
+import (
+	_ "github.com/pkg/errors"
+)
 
 func init() {
 
@@ -24,5 +28,12 @@ Any addtional flags sent to the npm command come after the --, e.g.
 	task.AddEnv("HOST_USER_ID", u.Uid)
 	task.AddEnv("HOST_GROUP_ID", u.Gid)
 	task.SetInitFunc(func(t *cali.Task, args []string) {
+		log.Infof("Serving http on port %s - http://127.0.0.1:%s", cli.FlagValues().GetString("port"), cli.FlagValues().GetString("port"))
+		task.HostConf.PortBindings = nat.PortMap{
+			nat.Port("4000/tcp"): []nat.PortBinding{
+				{HostIP: "0.0.0.0", HostPort: cli.FlagValues().GetString("port")},
+			},
+		}
+
 	})
 }


### PR DESCRIPTION
Vanilla `jekyll new` doesn't provide a Rakefile, so `jekyll serve` is useful.