### PR TITLE
don't error on dep failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,15 @@ $(BINARY): $(BINARY).darwin.amd64 $(BINARY).linux.amd64 $(BINARY).linux.arm
 	cp $(DEFAULT_SYSTEM_BINARY) $@
 
 $(BINARY).darwin.amd64: $(SOURCES)
-	${DOCKER_RUN_COMMAND} -e GOOS=darwin -e GOARCH=amd64 staticli/godep /bin/bash -c "dep ensure && go build ${LDFLAGS} -o $@"
+	${DOCKER_RUN_COMMAND} -e GOOS=darwin -e GOARCH=amd64 staticli/godep /bin/bash -c "dep ensure ; go build ${LDFLAGS} -o $@"
 	${DEFAULT_SHASUM_UTIL} $@ > $@.sha
 
 $(BINARY).linux.amd64: $(SOURCES)
-	${DOCKER_RUN_COMMAND} -e GOOS=linux -e GOARCH=amd64 staticli/godep /bin/bash -c "dep ensure && go build ${LDFLAGS} -o $@"
+	${DOCKER_RUN_COMMAND} -e GOOS=linux -e GOARCH=amd64 staticli/godep /bin/bash -c "dep ensure ; go build ${LDFLAGS} -o $@"
 	${DEFAULT_SHASUM_UTIL} $@ > $@.sha
 
 $(BINARY).linux.arm: $(SOURCES)
-	${DOCKER_RUN_COMMAND} -e GOOS=linux -e GOARCH=arm staticli/godep /bin/bash -c "dep ensure && go build ${LDFLAGS} -o $@"
+	${DOCKER_RUN_COMMAND} -e GOOS=linux -e GOARCH=arm staticli/godep /bin/bash -c "dep ensure ; go build ${LDFLAGS} -o $@"
 	${DEFAULT_SHASUM_UTIL} $@ > $@.sha
 
 


### PR DESCRIPTION
the move to `dep` for dependency management broke the ability to work offline.  This changes the Makefile so that if `dep` fails then the build still continues.  It's a bit noisy, but it works.