### PR TITLE
fixup names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,12 +14,6 @@ builds:
 archive:
   format: binary
   name_template: "{{ .ProjectName }}.{{ .Os }}.{{ .Arch }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
again, hard to test without doing a full release - but this should make the binary filenames match the ones we used to release, completing the work to switch to goreleaser.